### PR TITLE
add function to toggle line numbers on and off

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -53,7 +53,8 @@ nnoremap <leader>ev :vsp $MYVIMRC<CR>
 nnoremap <leader>et :exec ":vsp /Users/dblack/notes/vim/" . strftime('%m-%d-%y') . ".md"<CR>
 nnoremap <leader>ez :vsp ~/.zshrc<CR>
 nnoremap <leader>sv :source $MYVIMRC<CR>
-nnoremap <leader>l :call ToggleNumber()<CR>
+nnoremap <leader>l :call ToggleRelativeNumber()<CR>
+nnoremap <leader>tl :call ToggleNumber()<CR>
 nnoremap <leader><space> :noh<CR>
 nnoremap <leader>s :mksession<CR>
 nnoremap <leader>a :Ag 
@@ -128,13 +129,20 @@ let g:airline_right_sep = ''
 let g:airline_right_sep = ''
 " }}}
 " Custom Functions {{{
-function! ToggleNumber()
+function! ToggleRelativeNumber()
     if(&relativenumber == 1)
         set norelativenumber
         set number
     else
         set relativenumber
     endif
+endfunc
+
+function! ToggleNumber()
+  if(&relativenumber == 1)
+    set norelativenumber
+  endif
+  set invnumber
 endfunc
 
 " strips trailing whitespace at the end of files. this


### PR DESCRIPTION
Thanks for sharing the great vimrc, I've been using it for a couple years now. The toggle numbers function has odd behavior disabling line numbers from relative mode, so I've submitted a new function (with a bit of renaming). In my vimrc I use <leader> tr to toggle relative and <leader> tl to toggle on/off, but I've not changed handling of yours.

I did rename ToggleNumber to ToggleRelativeNumber, and than called the new function ToggleNumber.